### PR TITLE
fix: Multiple UI bugs

### DIFF
--- a/src/components/game-box.tsx
+++ b/src/components/game-box.tsx
@@ -139,7 +139,7 @@ export function GameBox({ game }: { game: GameEntry; isFirst?: boolean }) {
                 contextMenuContentRef.current = null;
                 setContextOpen(false);
                 setIsFocusLost(true);
-            } else {
+            } else if (navFieldRef.current) {
                 navFieldRef.current?.removeAttribute("data-gamepad-focus");
             }
             setClickCount(0);
@@ -147,11 +147,14 @@ export function GameBox({ game }: { game: GameEntry; isFirst?: boolean }) {
     }, [isWindowFocused])
 
     useEffect(() => {
-        if (!isContextOpen && !isFocusLost) {
-            navFieldRef.current?.setAttribute("data-gamepad-focus", "true");
-        } else if (isFocusLost) {
-            setIsFocusLost(false);
+        if (navFieldRef.current) {
+            if (!isContextOpen && !isFocusLost && contextMenuContentRef.current) {
+                navFieldRef.current?.setAttribute("data-gamepad-focus", "true");
+            } else if (isFocusLost) {
+                setIsFocusLost(false);
+            }
         }
+
     }, [isContextOpen])
 
     const openGame = () =>

--- a/src/components/main-page.tsx
+++ b/src/components/main-page.tsx
@@ -1,14 +1,33 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { GamepadNavField } from "../lib/context/gamepad-nav-field";
 import { GameLibrary } from "./game-library";
 import { Toolbar } from "./toolbar";
+import { UnlistenFn } from "@tauri-apps/api/event";
+import { getCurrentWindow } from '@tauri-apps/api/window'
 
 export function MainPage() {
     const [search, setSearch] = useState("");
+    const [isWindowFocused, setIsWindowFocused] = useState<boolean>(false);
+
+    useEffect(() => {
+        getCurrentWindow().isFocused().then(setIsWindowFocused);
+    }, [])
+
+    useEffect(() => {
+        const unlistenPromises: Promise<UnlistenFn>[] = [];
+        unlistenPromises.push(getCurrentWindow().onFocusChanged(({ payload }) => {
+            setIsWindowFocused(payload.valueOf());
+        }));
+        return () => {
+            unlistenPromises.forEach(unlistenPromise => unlistenPromise.then(unlisten => unlisten()));
+        }
+    }, []);
 
     return (
         <GamepadNavField debugName="main-page" zIndex={0}>
-            <div className="flex h-full flex-col">
+            <div className={`${isWindowFocused ? "flex h-full flex-col pointer-events-auto" :
+                                                "flex h-full flex-col pointer-events-none"}`}
+            >
                 <Toolbar onSearch={setSearch} />
                 <GameLibrary search={search} />
             </div>

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -113,10 +113,20 @@ function ToolbarButton({
     if (!tooltip) {
         return content;
     }
+    const [showTooltip, setShowTooltip] = useState(true);
+
     return (
-        <Tooltip delayDuration={0}>
-            <TooltipTrigger asChild>{content}</TooltipTrigger>
-            <TooltipContent>{tooltip}</TooltipContent>
+        <Tooltip delayDuration={500}>
+            <TooltipTrigger asChild onFocusCapture={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setShowTooltip(true);
+            }}  >{content}</TooltipTrigger>
+            <TooltipContent hidden={ !showTooltip } onBlurCapture={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setShowTooltip(false);
+            }} >{tooltip}</TooltipContent>
         </Tooltip>
     );
 }

--- a/src/components/ui/navigable.tsx
+++ b/src/components/ui/navigable.tsx
@@ -43,6 +43,9 @@ export function Navigable({
 
     const onSelect = useCallback(
         (btn: NavButton | null, e: GamepadButtonEvent) => {
+            if (!document.hasFocus()) {
+                return;
+            }
             propOnSelect?.(btn, e);
             if (!e.isPreventingDefault) {
                 document
@@ -59,6 +62,9 @@ export function Navigable({
     );
     const onButtonPress = useCallback(
         (btn: NavButton, e: GamepadButtonEvent) => {
+            if (!document.hasFocus()) {
+                return;
+            }
             propOnButtonPress?.(btn, e);
             if (!e.isPreventingDefault && defaultInput !== false) {
                 if (btn === "confirm") {

--- a/src/components/ui/navigable.tsx
+++ b/src/components/ui/navigable.tsx
@@ -43,9 +43,6 @@ export function Navigable({
 
     const onSelect = useCallback(
         (btn: NavButton | null, e: GamepadButtonEvent) => {
-            if (!document.hasFocus()) {
-                return;
-            }
             propOnSelect?.(btn, e);
             if (!e.isPreventingDefault) {
                 document
@@ -62,9 +59,6 @@ export function Navigable({
     );
     const onButtonPress = useCallback(
         (btn: NavButton, e: GamepadButtonEvent) => {
-            if (!document.hasFocus()) {
-                return;
-            }
             propOnButtonPress?.(btn, e);
             if (!e.isPreventingDefault && defaultInput !== false) {
                 if (btn === "confirm") {

--- a/src/handlers/gamepad.ts
+++ b/src/handlers/gamepad.ts
@@ -47,7 +47,7 @@ function gamepadLoop() {
     try {
         const now = Date.now();
         for (const gamepad of navigator.getGamepads()) {
-            if (!gamepad) {
+            if (!gamepad || !document.hasFocus()) {
                 continue;
             }
 

--- a/src/lib/context/gamepad-input-stack.tsx
+++ b/src/lib/context/gamepad-input-stack.tsx
@@ -98,10 +98,8 @@ export function GamepadInputStackProvider({ children }: PropsWithChildren) {
         if (!callbackList) {
             return;
         }
-        if (document.hasFocus()) {
-            for (const c of callbackList) {
-                c(e);
-            }
+        for (const c of callbackList) {
+            c(e);
         }
     }, []);
 

--- a/src/lib/context/gamepad-input-stack.tsx
+++ b/src/lib/context/gamepad-input-stack.tsx
@@ -84,9 +84,9 @@ export function GamepadInputStackProvider({ children }: PropsWithChildren) {
             }
             callbackList.push(callback);
             return () => {
-                const idx = callbackList.indexOf(callback);
+                const idx = callbackList!.indexOf(callback);
                 if (idx !== -1) {
-                    callbackList.splice(idx, 1);
+                    callbackList!.splice(idx, 1);
                 }
             };
         },
@@ -98,8 +98,10 @@ export function GamepadInputStackProvider({ children }: PropsWithChildren) {
         if (!callbackList) {
             return;
         }
-        for (const c of callbackList) {
-            c(e);
+        if (document.hasFocus()) {
+            for (const c of callbackList) {
+                c(e);
+            }
         }
     }, []);
 


### PR DESCRIPTION
* Fix launcher accepting controller input while the game is running. 
  Fixes #32. 
 Also, make it so that the cursor inputs are not accepted on window focus loss. ( As of now only the main page is handled, settings page and  the rest shall be done later ).

* Fix the context menu not highlighting the first option while opening the context menu with a controller. ( Prior to this you would need to go down to interact with the context menu and subsequently would not allow you to dismiss the context without selecting an option on the menu).

* Fix double clicking the context open button ( while just having used the controller ) would register as a double click, and would launch the game instead of the context menu.

* Fix the context menu after being opened and when the page loses focus still lingering on the page.

* Fix the tooltip hint for the buttons flickering after the page loses focus and regains focus. While at it increase tooltip hint delay from 0 -> 500ms.

This has been tested on windows.